### PR TITLE
Bootstrap frontend tabs shell and API skeleton

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../client/src/**/*.stories.@(ts|tsx|mdx)'],
+  addons: ['@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  docs: {
+    autodocs: 'tag'
+  }
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,17 @@
+import type { Preview } from '@storybook/react';
+import '../client/src/shared/design/tokens.css';
+import '../client/src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/
+      }
+    }
+  }
+};
+
+export default preview;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+Todas las fechas en formato ISO (AAAA-MM-DD). Seguimos SemVer.
+
+## [0.1.0] - 2024-04-24
+### Añadido
+- Bootstrap del monorepo con `client/` (Vite + React + TypeScript + Tailwind + Zustand + React Router + Zod + Axios) y `server/` (Express + TypeScript).
+- Navegación por tabs con rutas lazy, `AppLayout`, `TabsNav`, `PageContainer`, `EmptyState`, `Loading` y `ErrorBoundary`.
+- Sistema de diseño con tokens CSS, theming light/dark, primitives (Stack, Grid, Container, Button, Input, Card, Tabs) y Storybook documentado.
+- Estado global UI con persistencia, hooks compartidos y mocks de clases/usuarios.
+- Validaciones base con Zod y formulario de publicación.
+- Configuración de ESLint/Prettier, Vitest y Testing Library preparada.
+
+## [0.2.0] - 2024-05-xx
+### Roadmap
+- Autenticación básica, placeholders de login/signup y guards de ruta.
+
+## [0.3.0] - 2024-06-xx
+### Roadmap
+- CRUD de clases sobre mocks y acciones de reserva.
+
+## [0.4.0] - 2024-07-xx
+### Roadmap
+- Integración con API Express, contratos compartidos y persistencia real.
+
+## [1.0.0] - 2024-08-xx
+### Roadmap
+- Release estable con flujos de reserva y publicación completos, monitoreo y métricas en producción.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# Contexto del producto
+
+## Visión y problema
+Estudiantes busca democratizar el acceso a clases particulares conectando alumnos con profesores calificados de manera ágil. Actualmente los alumnos enfrentan dificultad para comparar ofertas, coordinar horarios y validar reputación docente. La plataforma resuelve esto con un catálogo curado, peticiones personalizadas y mensajería estructurada.
+
+## Alcance inicial
+- **Fase 1 (Frontend)**: experiencia SPA con navegación por tabs (`Explorar`, `Mis Clases`, `Publicar`, `Perfil`), componentes responsivos y accesibles, mocks de datos y formularios validados con Zod.
+- **Fase 2 (Backend)**: esqueleto Express listo para exponer endpoints públicos/privados, comenzando con `GET /health`.
+
+## Personas
+- **Alumna Camila (19 años, universitaria)**: necesita apoyo puntual para materias difíciles, valora disponibilidad rápida y comparaciones claras.
+- **Profesor Javier (35 años, profesional independiente)**: busca nuevos alumnos, quiere destacar su experiencia y gestionar reservas sin fricción.
+
+## Flujos clave
+1. **Explorar clases**: Camila filtra clases por tema/modalidad, consulta fichas y reserva.
+2. **Mis clases**: Camila revisa próximas sesiones, recibe recordatorios y evalúa profesores.
+3. **Publicar petición**: Camila describe su necesidad y recibe propuestas proactivas.
+4. **Perfil**: Javier/Camila ajustan información personal, preferencias y visibilidad.
+
+## KPIs iniciales
+- Tasa de conversión búsqueda → reserva.
+- Tiempo medio de respuesta a una petición publicada.
+- Número de reservas recurrentes por alumno.
+- Porcentaje de profesores con calificación ≥ 4.5.
+
+## Supuestos y riesgos
+- **Supuestos**: profesores aportan disponibilidad verificada; alumnos tienen medios de pago digitales; la plataforma ofrece soporte en horario extendido.
+- **Riesgos**: baja adopción de profesores al inicio, necesidad de verificación KYC, cumplimiento normativo local, escalamiento de soporte.
+
+## Notas de diseño y evolución
+- Los tokens de diseño permiten incorporar futuras paletas (corporativa, instituciones) sin reescribir componentes.
+- El sistema de tabs actúa como base para menús más complejos (sidebar o breadcrumbs) con la misma lógica accesible.
+- El backend crecerá con módulos de autenticación, catálogo, reservas y pagos; la API seguirá contratos tipados en `server/src/types`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# Estudiantes
+# Estudiantes — Plataforma B2C profesores ↔ alumnos
+
+## Visión y objetivo
+Estudiantes conecta alumnos con profesores especializados ofreciendo búsquedas por demanda, reservas ágiles y peticiones personalizadas. El objetivo inicial es entregar un frontend modular enfocado en tabs que pueda escalar hacia experiencias completas de marketplace con un backend listo para integrar contratos.
+
+## Arquitectura escalable
+El monorepo está dividido en dos paquetes:
+
+- `client/`: aplicación web Vite + React + TypeScript con enfoque **feature-first** y capas (`app/`, `pages/`, `features/`, `entities/`, `shared/`, `store/`, `mocks/`).
+- `server/`: esqueleto de API Express + TypeScript preparado para futuras extensiones.
+
+La arquitectura de frontend se basa en:
+
+- **Capas claras** para aislar routing (`app/`), páginas orquestadoras (`pages/`), lógica reutilizable por feature (`features/`), entidades de dominio (`entities/`) y utilidades compartidas (`shared/`).
+- **Componentes base** (`AppLayout`, `TabsNav`, `PageContainer`, `EmptyState`, `Loading`, `ErrorBoundary`) que establecen patrones de navegación accesible, manejo de errores y estados vacíos.
+- **Estado global ligero** con Zustand en `store/ui.ts` para preferencias UI (tema, ancho de contenedor, flags de navegación).
+- **Rutas lazy** (`React.lazy + Suspense`) para cada tab, reduciendo el tiempo de carga inicial.
+
+## Sistema de diseño y theming
+- **Tokens** (`src/shared/design/tokens.css`) definen espaciado, tipografías, colores, radios, sombras y breakpoints como CSS variables.
+- **Temas**: soporte `data-theme="light" | "dark"`, con valores intercambiables. El cambio de tema es inmediato desde la barra de tabs.
+- **Primitives** (`src/shared/ui/primitives/`) ofrecen building blocks (Stack, Grid, Container, Button, Input, Card, Tabs) con props composables y responsivas.
+- **Tailwind** extiende utilidades con los tokens (colores, spacing, radius, shadows) y activa container queries.
+- **Storybook** documenta primitives clave (Button, Card, Tabs) para facilitar iteraciones de diseño y validar cambios de tema.
+
+Cambiar la apariencia implica ajustar variables en `tokens.css` o extender `tailwind.config.ts`. Los componentes consumen esas abstracciones sin acoplarse a estilos específicos.
+
+## Estructura de carpetas
+```
+.
+├─ client/
+│  ├─ src/
+│  │  ├─ app/
+│  │  ├─ pages/
+│  │  ├─ features/
+│  │  ├─ entities/
+│  │  ├─ shared/
+│  │  ├─ store/
+│  │  └─ mocks/
+│  └─ ...
+├─ server/
+│  └─ src/
+├─ .storybook/
+├─ README.md
+├─ CONTEXT.md
+├─ CHANGELOG.md
+└─ REQUIREMENTS.md
+```
+Consulta la raíz de cada paquete para configuraciones específicas (Vite, Tailwind, TypeScript, ESLint/Prettier).
+
+## Guía de desarrollo
+### Frontend (`client/`)
+```bash
+cd client
+npm install
+npm run dev           # desarrollo con Vite
+npm run build         # build producción (tsc + vite build)
+npm run preview       # previsualización del build
+npm run test          # vitest
+npm run lint          # ESLint (reglas base + TypeScript + React Hooks)
+npm run format        # Prettier
+npm run storybook     # Storybook en http://localhost:6006
+```
+
+### Backend (`server/`)
+```bash
+cd server
+npm install
+npm run dev           # ts-node-dev con recarga
+npm run build         # compila a dist/
+npm run start         # ejecuta build compilado
+npm run lint          # ESLint
+npm run format        # Prettier
+```
+
+## Roadmap (alto nivel)
+- **0.1.0**: Bootstrap escalable con tabs lazy, tokens/temas, primitives, Tailwind y Storybook.
+- **0.2.0**: Autenticación básica (placeholder) y guards de ruta.
+- **0.3.0**: CRUD de clases sobre mocks con formularios validados por Zod.
+- **0.4.0**: Integración con API `server/` (contratos y fetch vía Axios).
+- **1.0.0**: Release estable con flujos de reserva y publicación en producción.
+
+## Criterios de calidad
+- **Accesibilidad**: navegación por teclado en tabs (`role=tablist` + atajos), foco visible, contraste validado, aria-labels en navegación y estados.
+- **Rendimiento**: rutas lazy, Suspense para loaders, assets diferidos, posibilidad de bundle analysis con `vite build --analyze`.
+- **Testing**: base lista para Vitest + Testing Library; los primitives tienen historias en Storybook para visual regression.
+- **Estilo**: ESLint y Prettier configurados, TypeScript estricto en ambos paquetes.
+- **DX**: alias de importaciones, tokens centralizados y mocks listos para desarrollar sin backend.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,85 @@
+# Requerimientos de instalación
+
+## Herramientas globales
+- Node.js 20.x o superior (`nvm install 20` recomendado)
+- npm 10.x (incluido con Node 20) o pnpm 8.x
+- Git 2.40+
+
+Verifica versiones:
+```bash
+node -v
+npm -v
+git --version
+```
+
+## Frontend (`client/`)
+### Dependencias clave
+- `react`, `react-dom`
+- `react-router-dom`
+- `zustand`
+- `zod`
+- `axios`
+
+### Dependencias de desarrollo
+- `typescript`
+- `vite`, `@vitejs/plugin-react`
+- `tailwindcss`, `postcss`, `autoprefixer`, `@tailwindcss/container-queries`
+- `@types/react`, `@types/react-dom`
+- `eslint`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint-config-prettier`, `eslint-plugin-react-hooks`
+- `prettier`
+- `vitest`, `@testing-library/react`, `@testing-library/user-event`, `@testing-library/jest-dom`
+- `storybook`, `@storybook/react-vite`, `@storybook/addon-essentials`
+- `clsx`
+
+### Instalación
+```bash
+cd client
+npm install
+```
+
+### Scripts
+```bash
+npm run dev            # servidor Vite
+npm run build          # build producción
+npm run preview        # vista previa del build
+npm run test           # Vitest + Testing Library
+npm run lint           # ESLint
+npm run format         # Prettier
+npm run storybook      # Storybook en http://localhost:6006
+npm run build-storybook
+```
+
+## Backend (`server/`)
+### Dependencias clave
+- `express`
+- `cors`
+- `helmet`
+
+### Dependencias de desarrollo
+- `typescript`
+- `ts-node-dev`
+- `@types/express`, `@types/node`
+- `eslint`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint-config-prettier`
+- `prettier`
+
+### Instalación
+```bash
+cd server
+npm install
+```
+
+### Scripts
+```bash
+npm run dev        # ts-node-dev con recarga
+npm run build      # compila a dist/
+npm run start      # ejecuta build compilado
+npm run lint       # ESLint
+npm run format     # Prettier
+```
+
+## Estándares de calidad
+- **Accesibilidad**: navegación por teclado en tabs (`role=tablist`, `aria-selected`), foco visible y contraste suficiente.
+- **Rendimiento**: code-splitting por ruta con `React.lazy`, posibilidad de ejecutar `vite build --analyze` para revisar bundle.
+- **Tipado**: TypeScript estricto, evitar `any`, contratos compartidos en `server/src/types`.
+- **Testing**: base configurada para Vitest + Testing Library; Storybook cubre primitives para visual QA.
+- **Diseño**: tokens y temas deben reflejarse en componentes y en Storybook.

--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint', 'react-hooks'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'prettier'],
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Estudiantes | Conecta con profesores</title>
+  </head>
+  <body class="bg-background text-foreground font-sans">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "estudiantes-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.22.4",
+    "clsx": "^2.1.1"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "^8.1.0",
+    "@storybook/react-vite": "^8.1.0",
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.1",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.7.1",
+    "@typescript-eslint/parser": "^7.7.1",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^9.2.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.38",
+    "prettier": "^3.2.5",
+    "storybook": "^8.1.0",
+    "tailwindcss": "^3.4.3",
+    "@tailwindcss/container-queries": "^0.1.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11",
+    "vitest": "^1.6.0"
+  }
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -1,0 +1,16 @@
+import { AppProviders } from './providers';
+import { AppLayout } from '@shared/ui/components/AppLayout';
+import { ErrorBoundary } from '@shared/ui/components/ErrorBoundary';
+import { AppRoutes } from './routes';
+
+export function App() {
+  return (
+    <AppProviders>
+      <ErrorBoundary>
+        <AppLayout>
+          <AppRoutes />
+        </AppLayout>
+      </ErrorBoundary>
+    </AppProviders>
+  );
+}

--- a/client/src/app/providers.tsx
+++ b/client/src/app/providers.tsx
@@ -1,0 +1,13 @@
+import { ReactNode, useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { useUIStore } from '@store/ui';
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  const theme = useUIStore((state) => state.theme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return <BrowserRouter>{children}</BrowserRouter>;
+}

--- a/client/src/app/routes.tsx
+++ b/client/src/app/routes.tsx
@@ -1,0 +1,48 @@
+import { lazy, Suspense } from 'react';
+import { Navigate, RouteObject, useRoutes } from 'react-router-dom';
+import { Loading } from '@shared/ui/components/Loading';
+
+const ExplorarPage = lazy(() => import('../pages/explorar/ExplorarPage').then((module) => ({ default: module.ExplorarPage })));
+const MisClasesPage = lazy(() => import('../pages/mis-clases/MisClasesPage').then((module) => ({ default: module.MisClasesPage })));
+const PublicarPage = lazy(() => import('../pages/publicar/PublicarPage').then((module) => ({ default: module.PublicarPage })));
+const PerfilPage = lazy(() => import('../pages/perfil/PerfilPage').then((module) => ({ default: module.PerfilPage })));
+
+const routes: RouteObject[] = [
+  { path: '/', element: <Navigate to="/explorar" replace /> },
+  {
+    path: '/explorar',
+    element: (
+      <Suspense fallback={<Loading label="Cargando clases" />}>
+        <ExplorarPage />
+      </Suspense>
+    )
+  },
+  {
+    path: '/mis-clases',
+    element: (
+      <Suspense fallback={<Loading label="Cargando tus clases" />}>
+        <MisClasesPage />
+      </Suspense>
+    )
+  },
+  {
+    path: '/publicar',
+    element: (
+      <Suspense fallback={<Loading label="Preparando formulario" />}>
+        <PublicarPage />
+      </Suspense>
+    )
+  },
+  {
+    path: '/perfil',
+    element: (
+      <Suspense fallback={<Loading label="Cargando perfil" />}>
+        <PerfilPage />
+      </Suspense>
+    )
+  }
+];
+
+export function AppRoutes() {
+  return useRoutes(routes);
+}

--- a/client/src/entities/clase/components/ClassCard.tsx
+++ b/client/src/entities/clase/components/ClassCard.tsx
@@ -1,0 +1,24 @@
+import { Card } from '@shared/ui/primitives/Card';
+import { Stack } from '@shared/ui/primitives/Stack';
+import { Button } from '@shared/ui/primitives/Button';
+import { Clase } from '../types';
+
+export function ClassCard({ clase }: { clase: Clase }) {
+  return (
+    <Card className="flex flex-col gap-sm">
+      <Stack direction="column" gap="xs">
+        <h3 className="text-lg font-semibold text-foreground">{clase.title}</h3>
+        <p className="text-sm text-foreground/70">{clase.description}</p>
+      </Stack>
+      <Stack direction="row" justify="between" align="center">
+        <div className="text-sm text-foreground/80">
+          <span className="font-medium">{clase.tutor}</span> · {clase.modality === 'online' ? 'Online' : 'Presencial'}
+          <span className="ml-2 text-foreground/60">⭐ {clase.rating.toFixed(1)}</span>
+        </div>
+        <Button size="sm" variant="primary" aria-label={`Reservar clase ${clase.title}`}>
+          Reservar · ${clase.pricePerHour}/h
+        </Button>
+      </Stack>
+    </Card>
+  );
+}

--- a/client/src/entities/clase/types.ts
+++ b/client/src/entities/clase/types.ts
@@ -1,0 +1,9 @@
+export type Clase = {
+  id: string;
+  title: string;
+  description: string;
+  tutor: string;
+  modality: 'online' | 'presencial';
+  rating: number;
+  pricePerHour: number;
+};

--- a/client/src/features/search/components/SearchBar.tsx
+++ b/client/src/features/search/components/SearchBar.tsx
@@ -1,0 +1,26 @@
+import { ChangeEvent } from 'react';
+import { Input } from '@shared/ui/primitives/Input';
+import { Stack } from '@shared/ui/primitives/Stack';
+
+type SearchBarProps = {
+  query: string;
+  onQueryChange: (value: string) => void;
+};
+
+export function SearchBar({ query, onQueryChange }: SearchBarProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onQueryChange(event.target.value);
+  };
+
+  return (
+    <Stack as="form" direction="column" gap="sm" role="search">
+      <Input
+        label="Buscar clases"
+        placeholder="Matemáticas, guitarra, programación..."
+        value={query}
+        onChange={handleChange}
+        aria-label="Buscar clases"
+      />
+    </Stack>
+  );
+}

--- a/client/src/features/search/hooks/useSearch.ts
+++ b/client/src/features/search/hooks/useSearch.ts
@@ -1,0 +1,21 @@
+import { useMemo, useState } from 'react';
+import { SearchFilters } from '../types';
+import { classes } from '@mocks/classes';
+
+export function useSearch() {
+  const [filters, setFilters] = useState<SearchFilters>({ query: '' });
+
+  const results = useMemo(() => {
+    if (!filters.query) return classes;
+    return classes.filter((clase) =>
+      clase.title.toLowerCase().includes(filters.query.toLowerCase()) ||
+      clase.description.toLowerCase().includes(filters.query.toLowerCase())
+    );
+  }, [filters.query]);
+
+  return {
+    filters,
+    setFilters,
+    results
+  };
+}

--- a/client/src/features/search/types.ts
+++ b/client/src/features/search/types.ts
@@ -1,0 +1,4 @@
+export type SearchFilters = {
+  query: string;
+  modality?: 'online' | 'presencial';
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+[data-theme] {
+  transition: background-color 0.3s ease, color 0.3s ease;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,12 @@
+import './shared/design/tokens.css';
+import './index.css';
+
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './app/App';
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/client/src/mocks/classes.ts
+++ b/client/src/mocks/classes.ts
@@ -1,0 +1,39 @@
+export type MockClass = {
+  id: string;
+  title: string;
+  description: string;
+  tutor: string;
+  modality: 'online' | 'presencial';
+  rating: number;
+  pricePerHour: number;
+};
+
+export const classes: MockClass[] = [
+  {
+    id: '1',
+    title: 'Matemáticas para bachillerato',
+    description: 'Refuerza tus conocimientos con sesiones personalizadas enfocadas en álgebra y cálculo.',
+    tutor: 'Laura Méndez',
+    modality: 'online',
+    rating: 4.8,
+    pricePerHour: 18
+  },
+  {
+    id: '2',
+    title: 'Guitarra acústica desde cero',
+    description: 'Aprende acordes, ritmos y técnica con un enfoque práctico y progresivo.',
+    tutor: 'Carlos Rivera',
+    modality: 'presencial',
+    rating: 4.6,
+    pricePerHour: 22
+  },
+  {
+    id: '3',
+    title: 'Programación web moderna',
+    description: 'Domina HTML, CSS, JavaScript y frameworks modernos con proyectos reales.',
+    tutor: 'Sofía Torres',
+    modality: 'online',
+    rating: 4.9,
+    pricePerHour: 25
+  }
+];

--- a/client/src/mocks/users.ts
+++ b/client/src/mocks/users.ts
@@ -1,0 +1,11 @@
+export type MockUser = {
+  id: string;
+  name: string;
+  role: 'profesor' | 'alumno';
+  avatarUrl?: string;
+};
+
+export const users: MockUser[] = [
+  { id: 'u1', name: 'Ana Castillo', role: 'alumno' },
+  { id: 'u2', name: 'Miguel Soto', role: 'profesor' }
+];

--- a/client/src/pages/explorar/ExplorarPage.tsx
+++ b/client/src/pages/explorar/ExplorarPage.tsx
@@ -1,0 +1,35 @@
+import { SearchBar } from '@features/search/components/SearchBar';
+import { useSearch } from '@features/search/hooks/useSearch';
+import { ClassCard } from '@entities/clase/components/ClassCard';
+import { Grid } from '@shared/ui/primitives/Grid';
+import { PageContainer } from '@shared/ui/components/PageContainer';
+import { EmptyState } from '@shared/ui/components/EmptyState';
+
+export function ExplorarPage() {
+  const { filters, setFilters, results } = useSearch();
+
+  return (
+    <PageContainer>
+      <header className="space-y-sm">
+        <h1 className="text-2xl font-semibold">Explorar clases</h1>
+        <p className="text-foreground/70">Descubre profesores verificados y clases a tu medida.</p>
+      </header>
+      <SearchBar
+        query={filters.query}
+        onQueryChange={(value) => setFilters((prev) => ({ ...prev, query: value }))}
+      />
+      {results.length > 0 ? (
+        <Grid gap="lg">
+          {results.map((clase) => (
+            <ClassCard key={clase.id} clase={clase} />
+          ))}
+        </Grid>
+      ) : (
+        <EmptyState
+          title="No encontramos resultados"
+          description="Ajusta los filtros o intenta con otra búsqueda."
+        />
+      )}
+    </PageContainer>
+  );
+}

--- a/client/src/pages/mis-clases/MisClasesPage.tsx
+++ b/client/src/pages/mis-clases/MisClasesPage.tsx
@@ -1,0 +1,18 @@
+import { PageContainer } from '@shared/ui/components/PageContainer';
+import { EmptyState } from '@shared/ui/components/EmptyState';
+
+export function MisClasesPage() {
+  return (
+    <PageContainer>
+      <header className="space-y-sm">
+        <h1 className="text-2xl font-semibold">Mis clases</h1>
+        <p className="text-foreground/70">Gestiona tus clases reservadas y próximas sesiones.</p>
+      </header>
+      <EmptyState
+        title="Aún no tienes clases reservadas"
+        description="Explora nuevas clases y reserva tu primera sesión con un profesor verificado."
+        action={{ label: 'Explorar clases', onClick: () => (window.location.href = '/explorar') }}
+      />
+    </PageContainer>
+  );
+}

--- a/client/src/pages/perfil/PerfilPage.tsx
+++ b/client/src/pages/perfil/PerfilPage.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { users } from '@mocks/users';
+import { Input } from '@shared/ui/primitives/Input';
+import { Button } from '@shared/ui/primitives/Button';
+import { Stack } from '@shared/ui/primitives/Stack';
+import { PageContainer } from '@shared/ui/components/PageContainer';
+
+const currentUser = users[0];
+
+export function PerfilPage() {
+  const [name, setName] = useState(currentUser.name);
+
+  return (
+    <PageContainer>
+      <Stack direction="column" gap="md" as="section" aria-labelledby="perfil-heading">
+        <div className="space-y-sm">
+          <h1 id="perfil-heading" className="text-2xl font-semibold">
+            Perfil
+          </h1>
+          <p className="text-foreground/70">
+            Actualiza tu información personal para que los profesores puedan conocerte mejor.
+          </p>
+        </div>
+        <form className="space-y-md" aria-describedby="perfil-helper">
+          <Input
+            label="Nombre completo"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            helperText="Este nombre será visible para los profesores."
+          />
+          <Button type="button" onClick={() => alert('Cambios guardados')} className="w-full sm:w-auto">
+            Guardar cambios
+          </Button>
+          <p id="perfil-helper" className="text-xs text-foreground/60">
+            Próximamente podrás actualizar foto, bio y preferencias de aprendizaje.
+          </p>
+        </form>
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/client/src/pages/publicar/PublicarPage.tsx
+++ b/client/src/pages/publicar/PublicarPage.tsx
@@ -1,0 +1,103 @@
+import { FormEvent, useState } from 'react';
+import { publishRequestSchema } from '@shared/lib/validation';
+import { Input } from '@shared/ui/primitives/Input';
+import { Button } from '@shared/ui/primitives/Button';
+import { Stack } from '@shared/ui/primitives/Stack';
+import { PageContainer } from '@shared/ui/components/PageContainer';
+
+export function PublicarPage() {
+  const [formValues, setFormValues] = useState({
+    title: '',
+    description: '',
+    category: '',
+    preferredSchedule: ''
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const result = publishRequestSchema.safeParse(formValues);
+    if (!result.success) {
+      const fieldErrors: Record<string, string> = {};
+      result.error.issues.forEach((issue) => {
+        const path = issue.path.join('.');
+        fieldErrors[path] = issue.message;
+      });
+      setErrors(fieldErrors);
+      setSubmitted(false);
+      return;
+    }
+
+    setErrors({});
+    setSubmitted(true);
+  };
+
+  return (
+    <PageContainer>
+      <Stack direction="column" gap="md" as="section" aria-labelledby="publicar-heading">
+        <div className="space-y-sm">
+          <h1 id="publicar-heading" className="text-2xl font-semibold">
+            Publicar una petición
+          </h1>
+          <p className="text-foreground/70">
+            Describe la clase que necesitas y recibe propuestas de profesores disponibles.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-md" noValidate>
+          <Input
+            name="title"
+            label="Título"
+            value={formValues.title}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, title: event.target.value }))}
+            helperText={errors.title}
+            aria-invalid={Boolean(errors.title)}
+            required
+          />
+          <div className="space-y-xs">
+            <label htmlFor="description" className="block text-sm font-medium text-foreground/80">
+              Descripción
+            </label>
+            <textarea
+              id="description"
+              name="description"
+              className="w-full rounded-md border border-foreground/10 bg-background px-3 py-2 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              rows={5}
+              value={formValues.description}
+              onChange={(event) => setFormValues((prev) => ({ ...prev, description: event.target.value }))}
+              aria-invalid={Boolean(errors.description)}
+              required
+            />
+            {errors.description && <p className="text-xs text-foreground/60">{errors.description}</p>}
+          </div>
+          <Input
+            name="category"
+            label="Categoría"
+            value={formValues.category}
+            onChange={(event) => setFormValues((prev) => ({ ...prev, category: event.target.value }))}
+            helperText={errors.category}
+            aria-invalid={Boolean(errors.category)}
+            required
+          />
+          <Input
+            name="preferredSchedule"
+            label="Horario preferido"
+            value={formValues.preferredSchedule}
+            onChange={(event) =>
+              setFormValues((prev) => ({ ...prev, preferredSchedule: event.target.value }))
+            }
+            helperText="Opcional"
+          />
+          <Button type="submit" className="w-full sm:w-auto">
+            Publicar petición
+          </Button>
+          {submitted && (
+            <p role="status" className="text-sm text-accent">
+              ¡Tu petición se ha enviado! Pronto recibirás propuestas.
+            </p>
+          )}
+        </form>
+      </Stack>
+    </PageContainer>
+  );
+}

--- a/client/src/shared/design/tokens.css
+++ b/client/src/shared/design/tokens.css
@@ -1,0 +1,56 @@
+:root {
+  /* Breakpoints */
+  --bp-sm: 30rem;
+  --bp-md: 48rem;
+  --bp-lg: 64rem;
+  --bp-xl: 80rem;
+
+  /* Typography */
+  --font-family-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-family-display: 'Sora', var(--font-family-sans);
+  --font-size-base: 16px;
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  /* Radius */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 1rem;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgb(15 23 42 / 0.08);
+  --shadow-md: 0 10px 15px -3px rgb(15 23 42 / 0.1);
+  --shadow-lg: 0 20px 25px -5px rgb(15 23 42 / 0.15);
+
+  /* Light theme */
+  --color-background: 250 250 255;
+  --color-foreground: 15 23 42;
+  --color-primary: 79 70 229;
+  --color-secondary: 14 165 233;
+  --color-accent: 22 163 74;
+}
+
+[data-theme='dark'] {
+  --color-background: 15 23 42;
+  --color-foreground: 226 232 240;
+  --color-primary: 129 140 248;
+  --color-secondary: 56 189 248;
+  --color-accent: 74 222 128;
+}
+
+@media (min-width: 30rem) {
+  :root {
+    font-size: 17px;
+  }
+}
+
+@media (min-width: 48rem) {
+  :root {
+    font-size: 18px;
+  }
+}

--- a/client/src/shared/hooks/useMediaQuery.ts
+++ b/client/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+type MediaQueryOptions = {
+  defaultValue?: boolean;
+};
+
+export function useMediaQuery(query: string, { defaultValue = false }: MediaQueryOptions = {}) {
+  const [matches, setMatches] = useState(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mediaQueryList = window.matchMedia(query);
+    const listener = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(mediaQueryList.matches);
+    mediaQueryList.addEventListener('change', listener);
+    return () => mediaQueryList.removeEventListener('change', listener);
+  }, [query]);
+
+  return matches;
+}

--- a/client/src/shared/lib/api.ts
+++ b/client/src/shared/lib/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3001',
+  headers: {
+    'Content-Type': 'application/json'
+  }
+});

--- a/client/src/shared/lib/validation.ts
+++ b/client/src/shared/lib/validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const publishRequestSchema = z.object({
+  title: z.string().min(3, 'El título debe tener al menos 3 caracteres'),
+  description: z.string().min(10, 'La descripción debe ser más detallada'),
+  category: z.string().min(1, 'Selecciona una categoría'),
+  preferredSchedule: z.string().optional()
+});
+
+export type PublishRequestInput = z.infer<typeof publishRequestSchema>;

--- a/client/src/shared/ui/components/AppLayout.tsx
+++ b/client/src/shared/ui/components/AppLayout.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+import { useUIStore } from '@store/ui';
+import { Container } from '../primitives/Container';
+import { TabsNav } from './TabsNav';
+
+const containerWidths = {
+  sm: 'max-w-3xl',
+  md: 'max-w-5xl',
+  lg: 'max-w-7xl'
+};
+
+type AppLayoutProps = {
+  children: ReactNode;
+};
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const containerWidth = useUIStore((state) => state.containerWidth);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-foreground/10">
+        <Container className="flex items-center justify-between py-sm gap-sm flex-wrap">
+          <div className="font-display text-lg">Estudiantes</div>
+          <TabsNav />
+        </Container>
+      </header>
+      <main className={`mx-auto w-full px-sm py-md ${containerWidths[containerWidth]}`}>
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/client/src/shared/ui/components/EmptyState.tsx
+++ b/client/src/shared/ui/components/EmptyState.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import { Button } from '../primitives/Button';
+import { Stack } from '../primitives/Stack';
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  icon?: ReactNode;
+};
+
+export function EmptyState({ title, description, action, icon }: EmptyStateProps) {
+  return (
+    <Stack as="section" direction="column" align="center" gap="md" className="text-center py-lg">
+      {icon && <div aria-hidden>{icon}</div>}
+      <Stack direction="column" gap="sm">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <p className="text-foreground/70 max-w-md">{description}</p>
+      </Stack>
+      {action && (
+        <Button onClick={action.onClick} variant="primary">
+          {action.label}
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/client/src/shared/ui/components/ErrorBoundary.tsx
+++ b/client/src/shared/ui/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { Button } from '../primitives/Button';
+import { Stack } from '../primitives/Stack';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false });
+    this.props.onReset?.();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Stack direction="column" gap="md" align="center" className="py-lg text-center">
+          <h2 className="text-xl font-semibold">Algo salió mal</h2>
+          <p className="max-w-md text-foreground/70">
+            Hemos encontrado un error inesperado. Intenta recargar la página o vuelve a intentarlo más
+            tarde.
+          </p>
+          <Button onClick={this.handleReset} variant="primary">
+            Reintentar
+          </Button>
+        </Stack>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/client/src/shared/ui/components/Loading.tsx
+++ b/client/src/shared/ui/components/Loading.tsx
@@ -1,0 +1,8 @@
+export function Loading({ label = 'Cargando' }: { label?: string }) {
+  return (
+    <div role="status" aria-live="polite" className="flex items-center gap-sm">
+      <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      <span className="text-sm text-foreground/80">{label}...</span>
+    </div>
+  );
+}

--- a/client/src/shared/ui/components/PageContainer.tsx
+++ b/client/src/shared/ui/components/PageContainer.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react';
+import { Container } from '../primitives/Container';
+
+export function PageContainer({ children }: { children: ReactNode }) {
+  return (
+    <Container className="space-y-md" data-testid="page-container">
+      {children}
+    </Container>
+  );
+}

--- a/client/src/shared/ui/components/TabsNav.tsx
+++ b/client/src/shared/ui/components/TabsNav.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { Button } from '../primitives/Button';
+import { useUIStore } from '@store/ui';
+
+const tabs = [
+  { to: '/explorar', label: 'Explorar Clases' },
+  { to: '/mis-clases', label: 'Mis Clases' },
+  { to: '/publicar', label: 'Publicar Petición' },
+  { to: '/perfil', label: 'Perfil' }
+];
+
+export function TabsNav() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const toggleTheme = useUIStore((state) => state.toggleTheme);
+
+  const activeIndex = useMemo(
+    () => tabs.findIndex((tab) => location.pathname.startsWith(tab.to)),
+    [location.pathname]
+  );
+  const focusIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  return (
+    <nav className="flex items-center gap-sm" aria-label="Navegación principal">
+      <div
+        role="tablist"
+        aria-orientation="horizontal"
+        className="flex flex-wrap gap-2 rounded-md bg-foreground/5 p-1"
+      >
+        {tabs.map((tab, index) => (
+          <NavLink
+            key={tab.to}
+            to={tab.to}
+            role="tab"
+            aria-selected={activeIndex === index}
+            tabIndex={focusIndex === index ? 0 : -1}
+            className={({ isActive }) =>
+              `rounded-md px-3 py-1 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors ${
+                isActive ? 'bg-primary text-background' : 'text-foreground/70 hover:text-foreground'
+              }`
+            }
+          >
+            {tab.label}
+          </NavLink>
+        ))}
+      </div>
+      <Button variant="ghost" size="sm" onClick={toggleTheme} aria-label="Cambiar tema">
+        Tema
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => navigate('/publicar')}
+        aria-label="Publicar una nueva petición"
+      >
+        Publicar
+      </Button>
+    </nav>
+  );
+}

--- a/client/src/shared/ui/primitives/Button.stories.tsx
+++ b/client/src/shared/ui/primitives/Button.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Primitives/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered'
+  },
+  args: {
+    children: 'Acción principal'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary'
+  }
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary'
+  }
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost'
+  }
+};

--- a/client/src/shared/ui/primitives/Button.tsx
+++ b/client/src/shared/ui/primitives/Button.tsx
@@ -1,0 +1,36 @@
+import { ButtonHTMLAttributes, forwardRef } from 'react';
+import clsx from 'clsx';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+const baseStyles = 'inline-flex items-center justify-center font-medium rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors disabled:opacity-60 disabled:cursor-not-allowed';
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary: 'bg-primary text-background hover:bg-primary/90',
+  secondary: 'bg-secondary text-background hover:bg-secondary/90',
+  ghost: 'bg-transparent text-foreground hover:bg-foreground/10'
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: 'h-9 px-3 text-sm',
+  md: 'h-10 px-4 text-base',
+  lg: 'h-12 px-6 text-lg'
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', size = 'md', className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={clsx(baseStyles, variantStyles[variant], sizeStyles[size], className)}
+      {...props}
+    />
+  )
+);
+
+Button.displayName = 'Button';

--- a/client/src/shared/ui/primitives/Card.stories.tsx
+++ b/client/src/shared/ui/primitives/Card.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from './Card';
+import { Stack } from './Stack';
+
+const meta: Meta<typeof Card> = {
+  title: 'Primitives/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="max-w-md">
+      <Stack direction="column" gap="sm">
+        <h3 className="text-lg font-semibold">Ficha de clase</h3>
+        <p className="text-sm text-foreground/70">
+          Usa el componente Card para agrupar información relevante dentro de superficies elevadas.
+        </p>
+      </Stack>
+    </Card>
+  )
+};

--- a/client/src/shared/ui/primitives/Card.tsx
+++ b/client/src/shared/ui/primitives/Card.tsx
@@ -1,0 +1,14 @@
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+
+export function Card({ className, ...props }: ComponentPropsWithoutRef<'div'>) {
+  return (
+    <div
+      className={clsx(
+        'rounded-lg border border-foreground/10 bg-background/80 p-md shadow-sm backdrop-blur-sm supports-[backdrop-filter]:bg-background/60',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/client/src/shared/ui/primitives/Container.tsx
+++ b/client/src/shared/ui/primitives/Container.tsx
@@ -1,0 +1,6 @@
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+
+export function Container({ className, ...props }: ComponentPropsWithoutRef<'div'>) {
+  return <div className={clsx('mx-auto w-full max-w-7xl px-sm', className)} {...props} />;
+}

--- a/client/src/shared/ui/primitives/Grid.tsx
+++ b/client/src/shared/ui/primitives/Grid.tsx
@@ -1,0 +1,36 @@
+import { ComponentPropsWithoutRef } from 'react';
+import clsx from 'clsx';
+
+const columnsMap = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4'
+} as const;
+
+const gapMap = {
+  xs: 'gap-[var(--space-xs)]',
+  sm: 'gap-[var(--space-sm)]',
+  md: 'gap-[var(--space-md)]',
+  lg: 'gap-[var(--space-lg)]'
+} as const;
+
+type GridProps = ComponentPropsWithoutRef<'div'> & {
+  columns?: keyof typeof columnsMap;
+  gap?: keyof typeof gapMap;
+};
+
+export function Grid({ columns = 1, gap = 'md', className, ...props }: GridProps) {
+  return (
+    <div
+      className={clsx(
+        'grid auto-rows-fr',
+        columnsMap[columns],
+        gapMap[gap],
+        'md:grid-cols-[repeat(auto-fit,minmax(min(18rem,100%),1fr))]',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/client/src/shared/ui/primitives/Input.tsx
+++ b/client/src/shared/ui/primitives/Input.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  label?: string;
+  helperText?: string;
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, helperText, className, id, ...props }, ref) => {
+    const inputId = id ?? props.name;
+
+    return (
+      <div className="space-y-xs">
+        {label && (
+          <label htmlFor={inputId} className="block text-sm font-medium text-foreground/80">
+            {label}
+          </label>
+        )}
+        <input
+          id={inputId}
+          ref={ref}
+          className={clsx(
+            'w-full rounded-md border border-foreground/10 bg-background px-3 py-2 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40',
+            className
+          )}
+          {...props}
+        />
+        {helperText && <p className="text-xs text-foreground/60">{helperText}</p>}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';

--- a/client/src/shared/ui/primitives/Stack.tsx
+++ b/client/src/shared/ui/primitives/Stack.tsx
@@ -1,0 +1,58 @@
+import { ComponentPropsWithoutRef, ElementType } from 'react';
+import clsx from 'clsx';
+
+type StackProps<T extends ElementType> = {
+  as?: T;
+  direction?: 'row' | 'column';
+  gap?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  align?: 'start' | 'center' | 'end' | 'stretch';
+  justify?: 'start' | 'center' | 'end' | 'between';
+} & ComponentPropsWithoutRef<T>;
+
+const alignMap = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch'
+} as const;
+
+const justifyMap = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between'
+} as const;
+
+const gapMap = {
+  xs: 'gap-[var(--space-xs)]',
+  sm: 'gap-[var(--space-sm)]',
+  md: 'gap-[var(--space-md)]',
+  lg: 'gap-[var(--space-lg)]',
+  xl: 'gap-[var(--space-xl)]'
+} as const;
+
+export function Stack<T extends ElementType = 'div'>({
+  as,
+  direction = 'row',
+  gap = 'md',
+  align = 'stretch',
+  justify = 'start',
+  className,
+  ...props
+}: StackProps<T>) {
+  const Component = as ?? 'div';
+
+  return (
+    <Component
+      className={clsx(
+        'flex',
+        direction === 'column' ? 'flex-col' : 'flex-row',
+        gapMap[gap],
+        alignMap[align],
+        justifyMap[justify],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/client/src/shared/ui/primitives/Tabs.stories.tsx
+++ b/client/src/shared/ui/primitives/Tabs.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs';
+import { Stack } from './Stack';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Primitives/Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tabs>;
+
+export const Playground: Story = {
+  render: () => (
+    <Tabs defaultValue="uno" className="max-w-lg">
+      <TabsList>
+        <TabsTrigger value="uno">Tab uno</TabsTrigger>
+        <TabsTrigger value="dos">Tab dos</TabsTrigger>
+        <TabsTrigger value="tres">Tab tres</TabsTrigger>
+      </TabsList>
+      <TabsContent value="uno">
+        <Stack direction="column" gap="sm">
+          <h3 className="text-lg font-semibold">Contenido uno</h3>
+          <p className="text-sm text-foreground/70">Información detallada del primer tab.</p>
+        </Stack>
+      </TabsContent>
+      <TabsContent value="dos">
+        <p className="text-sm text-foreground/70">Contenido alternativo para el segundo tab.</p>
+      </TabsContent>
+      <TabsContent value="tres">
+        <p className="text-sm text-foreground/70">Personaliza y reorganiza los tabs como prefieras.</p>
+      </TabsContent>
+    </Tabs>
+  )
+};

--- a/client/src/shared/ui/primitives/Tabs.tsx
+++ b/client/src/shared/ui/primitives/Tabs.tsx
@@ -1,0 +1,145 @@
+import {
+  KeyboardEventHandler,
+  createContext,
+  PropsWithChildren,
+  ReactNode,
+  useContext,
+  useId,
+  useMemo,
+  useState
+} from 'react';
+import clsx from 'clsx';
+
+type TabsContextValue = {
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+  idPrefix: string;
+};
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+type TabsProps = PropsWithChildren<{
+  defaultValue: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+}>;
+
+export function Tabs({ defaultValue, onValueChange, className, children }: TabsProps) {
+  const [activeTab, setActiveTab] = useState(defaultValue);
+  const idPrefix = useId();
+
+  const value = useMemo(
+    () => ({
+      activeTab,
+      setActiveTab: (value: string) => {
+        setActiveTab(value);
+        onValueChange?.(value);
+      },
+      idPrefix
+    }),
+    [activeTab, idPrefix, onValueChange]
+  );
+
+  return (
+    <TabsContext.Provider value={value}>
+      <div className={clsx('flex flex-col gap-sm', className)}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+type TabsListProps = PropsWithChildren<{ className?: string }>;
+
+export function TabsList({ className, children }: TabsListProps) {
+  useTabsContext();
+
+  return (
+    <div
+      role="tablist"
+      aria-orientation="horizontal"
+      className={clsx('inline-flex gap-1 rounded-lg bg-foreground/5 p-1', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+type TabsTriggerProps = {
+  value: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function TabsTrigger({ value, children, className }: TabsTriggerProps) {
+  const { activeTab, setActiveTab, idPrefix } = useTabsContext();
+  const isActive = activeTab === value;
+
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const triggers = event.currentTarget.parentElement?.querySelectorAll('[role="tab"]');
+      if (!triggers || triggers.length === 0) return;
+      const currentIndex = Array.from(triggers).indexOf(event.currentTarget);
+      const nextIndex = event.key === 'ArrowRight'
+        ? (currentIndex + 1) % triggers.length
+        : (currentIndex - 1 + triggers.length) % triggers.length;
+      (triggers[nextIndex] as HTMLButtonElement).focus();
+      (triggers[nextIndex] as HTMLButtonElement).click();
+    }
+  };
+
+  return (
+    <button
+      role="tab"
+      id={`${idPrefix}-tab-${value}`}
+      aria-selected={isActive}
+      aria-controls={`${idPrefix}-panel-${value}`}
+      tabIndex={isActive ? 0 : -1}
+      onClick={() => setActiveTab(value)}
+      onKeyDown={handleKeyDown}
+      className={clsx(
+        'rounded-md px-3 py-1 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary transition-colors',
+        isActive ? 'bg-primary text-background shadow-sm' : 'text-foreground/70 hover:text-foreground',
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+type TabsContentProps = PropsWithChildren<{
+  value: string;
+  className?: string;
+}>;
+
+export function TabsContent({ value, className, children }: TabsContentProps) {
+  const { activeTab, idPrefix } = useTabsContext();
+  const isActive = activeTab === value;
+
+  return (
+    <div
+      role="tabpanel"
+      id={`${idPrefix}-panel-${value}`}
+      aria-labelledby={`${idPrefix}-tab-${value}`}
+      hidden={!isActive}
+      className={clsx('rounded-md border border-foreground/10 p-md', className)}
+    >
+      {isActive && children}
+    </div>
+  );
+}
+
+function useTabsContext() {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs components must be used within <Tabs>');
+  }
+  return context;
+}
+
+export const TabsPrimitives = {
+  Root: Tabs,
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Content: TabsContent
+};

--- a/client/src/store/ui.ts
+++ b/client/src/store/ui.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type Theme = 'light' | 'dark';
+
+type UIState = {
+  theme: Theme;
+  containerWidth: 'sm' | 'md' | 'lg';
+  showCompactNav: boolean;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+  setContainerWidth: (width: UIState['containerWidth']) => void;
+  setShowCompactNav: (value: boolean) => void;
+};
+
+export const useUIStore = create<UIState>()(
+  persist(
+    (set, get) => ({
+      theme: 'light',
+      containerWidth: 'lg',
+      showCompactNav: false,
+      toggleTheme: () => {
+        const nextTheme = get().theme === 'light' ? 'dark' : 'light';
+        set({ theme: nextTheme });
+        document.documentElement.setAttribute('data-theme', nextTheme);
+      },
+      setTheme: (theme) => {
+        set({ theme });
+        document.documentElement.setAttribute('data-theme', theme);
+      },
+      setContainerWidth: (width) => set({ containerWidth: width }),
+      setShowCompactNav: (value) => set({ showCompactNav: value })
+    }),
+    {
+      name: 'ui-preferences'
+    }
+  )
+);

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,0 +1,42 @@
+import type { Config } from 'tailwindcss';
+import containerQueries from '@tailwindcss/container-queries';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx,mdx}'],
+  darkMode: ['attribute', '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        foreground: 'rgb(var(--color-foreground) / <alpha-value>)',
+        primary: 'rgb(var(--color-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--color-secondary) / <alpha-value>)',
+        accent: 'rgb(var(--color-accent) / <alpha-value>)'
+      },
+      fontFamily: {
+        sans: 'var(--font-family-sans)',
+        display: 'var(--font-family-display)'
+      },
+      spacing: {
+        xs: 'var(--space-xs)',
+        sm: 'var(--space-sm)',
+        md: 'var(--space-md)',
+        lg: 'var(--space-lg)',
+        xl: 'var(--space-xl)'
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)'
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)'
+      }
+    }
+  },
+  plugins: [containerQueries]
+};
+
+export default config;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,51 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "types": [
+      "vite/client",
+      "vitest/globals"
+    ],
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": [
+        "app/*"
+      ],
+      "@pages/*": [
+        "pages/*"
+      ],
+      "@features/*": [
+        "features/*"
+      ],
+      "@entities/*": [
+        "entities/*"
+      ],
+      "@shared/*": [
+        "shared/*"
+      ],
+      "@store/*": [
+        "store/*"
+      ],
+      "@mocks/*": [
+        "mocks/*"
+      ]
+    }
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "vite.config.ts",
+    "tailwind.config.ts",
+    "postcss.config.js"
+  ]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  },
+  build: {
+    target: 'esnext'
+  }
+});

--- a/server/.eslintrc.cjs
+++ b/server/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2021: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  rules: {}
+};

--- a/server/.prettierrc
+++ b/server/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "estudiantes-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.7.1",
+    "@typescript-eslint/parser": "^7.7.1",
+    "eslint": "^9.2.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { healthRouter } from './routes/health';
+
+const app = express();
+const port = process.env.PORT ?? 3001;
+
+app.use(cors());
+app.use(helmet());
+app.use(express.json());
+
+app.use('/health', healthRouter);
+
+app.get('/', (_req, res) => {
+  res.status(200).json({
+    message: 'Estudiantes API v0.1.0',
+    links: {
+      health: '/health'
+    }
+  });
+});
+
+app.listen(port, () => {
+  console.log(`API listening on port ${port}`);
+});

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+
+export const healthRouter = Router();
+
+healthRouter.get('/', (_req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    timestamp: new Date().toISOString()
+  });
+});

--- a/server/src/types/index.d.ts
+++ b/server/src/types/index.d.ts
@@ -1,0 +1,6 @@
+export type UserRole = 'profesor' | 'alumno';
+
+export interface ApiResponse<T> {
+  data: T;
+  meta?: Record<string, unknown>;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- set up the Vite + React + TypeScript client with feature-first foldering, lazy tab routes, shared layout components, Zustand UI store, and mocked data
- add design system tokens, primitives, Tailwind theming, Storybook stories, and accessibility-focused navigation
- scaffold an Express + TypeScript API skeleton alongside repository documentation (README, CONTEXT, CHANGELOG, REQUIREMENTS) and lint/format configs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eff172f9a88323b5e72bc091c3f0b0